### PR TITLE
Implement local auth guard that acts as a middleware to route API

### DIFF
--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -1,6 +1,7 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Post, Request, UseGuards } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { CreateUserDto } from '../user/dto/create-user.dto';
+import { LocalAuthGuard } from './guards/local-auth/local-auth.guard';
 
 @Controller('auth') // this is the parent endpoint API
 export class AuthController {
@@ -10,6 +11,42 @@ export class AuthController {
     return this.authService.registerUser(createUserDto);
   }
 
+  /**
+   * ❓ How does LocalAuthGuard communicate with LocalStrategy?
+   *
+   * Even though there's no direct import or reference between LocalAuthGuard and LocalStrategy,
+   * PassportJS (together with NestJS integration) handles the connection automatically.
+   *
+   * Here's how:
+   * - LocalAuthGuard extends `AuthGuard('local')`.
+   * - The string `'local'` refers to the strategy name used in `LocalStrategy`, powered by `passport-local`.
+   * - Passport uses this string to internally resolve the correct strategy when the guard is triggered.
+   * - As long as `LocalStrategy` is registered in the module's `providers`, it becomes available globally.
+   *
+   * ✅ You do NOT need to manually connect the guard to the strategy.
+   * Passport + NestJS uses metadata and dependency injection to make the link behind the scenes.
+   */
+
+  /**
+   * The `@UseGuards` decorator acts like middleware to protect API routes
+   *
+   *
+   *
+   * How it works (step-by-step):
+   *
+   * 1) The client sends a POST request to /auth/signin.
+   * 2) The request first passes through the LocalAuthGuard.
+   * 3) LocalAuthGuard triggers the LocalStrategy (see: apps/backend/src/auth/strategies/local.strategy.ts).
+   * 4) Inside LocalStrategy, email and password are extracted from the request body,
+   *    then passed to the `validate()` method and the `validateLocalUser()` function in the AuthService.
+   * 5) The `validateLocalUser()` function returns a user object (e.g. { id, name }).
+   * 6) The result is attached to the request as `request.user` by Passport from `validate` function.
+   */
+  @UseGuards(LocalAuthGuard)
   @Post('signin') // this endpoint will be /auth/signin
-  login() {}
+  login(@Request() req) {
+    // For now, this returns the user object.
+    // In a real-world application, you would typically return a JWT access token and refresh token instead.
+    return req.user;
+  }
 }

--- a/apps/backend/src/auth/guards/local-auth/local-auth.guard.spec.ts
+++ b/apps/backend/src/auth/guards/local-auth/local-auth.guard.spec.ts
@@ -1,0 +1,23 @@
+import { ExecutionContext } from '@nestjs/common';
+import { LocalAuthGuard } from './local-auth.guard';
+import { AuthGuard } from '@nestjs/passport';
+
+describe('LocalAuthGuard', () => {
+  it('should be defined', () => {
+    expect(new LocalAuthGuard()).toBeDefined();
+  });
+
+  it('should extend AuthGuard with "local" strategy', async () => {
+    const guard = new LocalAuthGuard();
+
+    // Mock ExecutionContext
+    const mockContext = {} as ExecutionContext;
+
+    // Check if it has the canActivate method (inherited from AuthGuard)
+    expect(typeof guard.canActivate).toBe('function');
+
+    // This indirectly confirm it behaves like an AuthGuard with a strategy
+    // We can't directly access the string 'local'
+    expect(guard).toBeInstanceOf(AuthGuard('local'));
+  });
+});

--- a/apps/backend/src/auth/guards/local-auth/local-auth.guard.ts
+++ b/apps/backend/src/auth/guards/local-auth/local-auth.guard.ts
@@ -1,0 +1,6 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+// Always remember that AuthGuard is a function that we need to pass the name parameter of the local strategy, which by default is `local`
+export class LocalAuthGuard extends AuthGuard('local') {}


### PR DESCRIPTION
This PR includes inline documentation to clarify how the `LocalAuthGuard` communicates with the `LocalStrategy` using PassportJS and NestJS integration.

```typescript
/**
 * ❓ How does LocalAuthGuard communicate with LocalStrategy?
 *
 * Even though there's no direct import or reference between LocalAuthGuard and LocalStrategy,
 * PassportJS (together with NestJS integration) handles the connection automatically.
 *
 * Here's how:
 * - LocalAuthGuard extends `AuthGuard('local')`.
 * - The string `'local'` refers to the strategy name used in `LocalStrategy`, powered by `passport-local`.
 * - Passport uses this string to internally resolve the correct strategy when the guard is triggered.
 * - As long as `LocalStrategy` is registered in the module's `providers`, it becomes available globally.
 *
 * ✅ You do NOT need to manually connect the guard to the strategy.
 * Passport + NestJS uses metadata and dependency injection to make the link behind the scenes.
 */

``` 


This explanation aims to help developers understand the implicit connection and reduce confusion when reading the codebase.

![Screenshot 2025-05-25 161100](https://github.com/user-attachments/assets/20e09ed5-de9c-42e6-9b58-5338b4edd72f)
